### PR TITLE
Replace i3-input with rofi for workspace creation and switching

### DIFF
--- a/.i3/config
+++ b/.i3/config
@@ -359,9 +359,9 @@ bindcode Mod4+58 exec --no-startup-id i3-input -F 'mark %s ' -l 1 -P 'Mark: '
 bindcode Mod4+57 exec --no-startup-id i3-input -F '[con_mark="%s"] focus' -l 1 -P 'Goto: '
 
 # Go to/create workspace with arbitrary name (Super+w)[Super+t]
-bindcode Mod4+28 exec --no-startup-id i3-input -F 'workspace %s' -l 8 -P 'Workspace: '
+bindcode Mod4+28 exec --no-startup-id "rofi -modi 'Workspace:i3wslist.sh,Move to Workspace:i3wsmove.sh' -show Workspace"
 # Move to workspace with arbitrary name (Super+Shift+w)[Super+Shift+t]
-bindcode Mod4+Shift+28 exec --no-startup-id i3-input -F 'move container to workspace %s' -l 8 -P 'Move to workspace: '
+bindcode Mod4+Shift+28 exec --no-startup-id "rofi -modi 'Workspace:i3wslist.sh,Move to Workspace:i3wsmove.sh' -show 'Move to Workspace'"
 
 # Run arbitrary i3 command (Super+Alt+Return)[Super+Alt+Return]
 bindcode Mod4+Mod1+36 exec ~/bin/i3_run -fn "$dmenufonttype" -nb "$c_dark_blue" -nf "$c_white" -sb "$c_neutral_blue" -sf "$c_black" -p "i3-msg"

--- a/bin/i3wslist.sh
+++ b/bin/i3wslist.sh
@@ -1,0 +1,16 @@
+#!/bin/bash - 
+wslist () {
+    i3-msg -t get_workspaces | tr ',' '\n' | grep '"name":' | sed 's/"name":"\(.*\)"/\1/g' | sort -V
+}
+
+case $1 in
+    [0-9]*)
+        i3-msg workspace number "$1"
+        ;;
+    ?*)
+        i3-msg workspace "$1"
+        ;;
+    *)
+        wslist
+        ;;
+esac

--- a/bin/i3wslist.sh
+++ b/bin/i3wslist.sh
@@ -5,10 +5,10 @@ wslist () {
 
 case $1 in
     [0-9]*)
-        i3-msg workspace number "$1"
+        i3-msg workspace number "$1" > /dev/null
         ;;
     ?*)
-        i3-msg workspace "$1"
+        i3-msg workspace "$1" > /dev/null
         ;;
     *)
         wslist

--- a/bin/i3wsmove.sh
+++ b/bin/i3wsmove.sh
@@ -1,0 +1,16 @@
+#!/bin/bash - 
+wslist () {
+    i3-msg -t get_workspaces | tr ',' '\n' | grep '"name":' | sed 's/"name":"\(.*\)"/\1/g' | sort -V
+}
+
+case $1 in
+    [0-9]*)
+        i3-msg move container to workspace number "$1"
+        ;;
+    ?*)
+        i3-msg move container to workspace "$1"
+        ;;
+    *)
+        wslist
+        ;;
+esac

--- a/bin/i3wsmove.sh
+++ b/bin/i3wsmove.sh
@@ -5,10 +5,10 @@ wslist () {
 
 case $1 in
     [0-9]*)
-        i3-msg move container to workspace number "$1"
+        i3-msg move container to workspace number "$1" > /dev/null
         ;;
     ?*)
-        i3-msg move container to workspace "$1"
+        i3-msg move container to workspace "$1" > /dev/null
         ;;
     *)
         wslist


### PR DESCRIPTION
Workspace switching with `i3-input` has quite a few limitations. Not the least of them being that it does not present a list of available workspaces nor does it allow for partial naming.

This is an initial version still has some rough corners (manual parsing JSON output of `i3-msg`) but it is functional and does improve UX.
